### PR TITLE
Supply the taskId to the callback functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Framework disconnects the HTTP client (Browser/RestFul API) request from waiting for long running server-side actions to complete and shields the application server from clients attempting to re-submit duplicate requests.
 
-The play-async framework provides the tools to transform a synchronous controller action into a true async controller, where the client drives the polling for the requeted resource back to the server.
+The play-async framework provides the tools to transform a synchronous controller action into a true async controller, where the client drives the polling for the requested resource back to the server.
 
 ##Background
 

--- a/test/asyncmvc/async/TimedEventSpec.scala
+++ b/test/asyncmvc/async/TimedEventSpec.scala
@@ -16,9 +16,12 @@
 
 package asyncmvc.async
 
+import org.scalatest.concurrent.PatienceConfiguration.Interval
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.time.{Milliseconds, Span}
 import uk.gov.hmrc.play.asyncmvc.async.{TimedEvent}
 import uk.gov.hmrc.play.test.UnitSpec
+import scala.concurrent.duration._
 
 class TimedEventSpec extends UnitSpec with ScalaFutures with Eventually {
 
@@ -27,10 +30,14 @@ class TimedEventSpec extends UnitSpec with ScalaFutures with Eventually {
     "Incur a delay before executing the Future" in {
 
       val now = System.currentTimeMillis()
+      val response: Int = await(TimedEvent.delayedSuccess(2000, 999))(4 seconds)
 
-      await(TimedEvent.delayedSuccess(1000, 0))
+      val processTime = System.currentTimeMillis()
+      println(s"start time $now - Expired time $processTime")
 
-      System.currentTimeMillis() shouldBe >(now + 1000)
+      response shouldBe 999
+      processTime shouldBe >(now + 1000)
+
     }
   }
 }

--- a/test/asyncmvc/controllers/AsyncSetup.scala
+++ b/test/asyncmvc/controllers/AsyncSetup.scala
@@ -17,7 +17,6 @@
 package asyncmvc.controllers
 
 import akka.actor.{ActorRef, Props}
-import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.asyncmvc.async.{Cache, TimedEvent}
 import uk.gov.hmrc.play.asyncmvc.example.connectors.{Stock, StockConnector}
 import uk.gov.hmrc.play.asyncmvc.example.controllers.{ExampleAsyncController, InputForm}
@@ -59,7 +58,7 @@ trait AsyncSetup {
       }
 
       override def getStock(id: Long): Future[Stock] = {
-        TimedEvent.delayedSuccess(delay, 0).map(a => {
+        TimedEvent.delayedSuccess(delay, 0).map(_ => {
           Stock("TEST DYNAMIC DELAY", id)
         })
       }
@@ -72,9 +71,9 @@ trait AsyncSetup {
 
     trait ControllerUnderTest extends ExampleAsyncController {
       def getName :String = ???
-      override lazy val sessionHttpCache = cache
+      override lazy val taskCache = cache
       override def waitMode = false
-      override lazy val asyncActor: ActorRef = Akka.system.actorOf(Props(new AsyncMVCAsyncActor(sessionHttpCache, CLIENT_TIMEOUT)), name = getName)
+      override lazy val asyncActor: ActorRef = Akka.system.actorOf(Props(new AsyncMVCAsyncActor(taskCache, CLIENT_TIMEOUT)), name = getName)
     }
 
     val cache = new Cache[TaskCache] {
@@ -132,7 +131,7 @@ trait AsyncSetup {
       override lazy val stockConnector: StockConnector = dynamicDelayStockConnector(1000)
       override def buildUniqueId() = testSessionId
       override def getClientTimeout = 1
-      override lazy val asyncActor: ActorRef = Akka.system.actorOf(Props(new AsyncMVCAsyncActor(sessionHttpCache, 1000)), name = getName)
+      override lazy val asyncActor: ActorRef = Akka.system.actorOf(Props(new AsyncMVCAsyncActor(cache, 1000)), name = getName)
     }
   }
 
@@ -147,7 +146,7 @@ trait AsyncSetup {
       override def waitMode = true
       override def getClientTimeout = 1
       override def blockingDelayTime = 1
-      override lazy val asyncActor: ActorRef = Akka.system.actorOf(Props(new AsyncMVCAsyncActor(sessionHttpCache, 100)), name = getName)
+      override lazy val asyncActor: ActorRef = Akka.system.actorOf(Props(new AsyncMVCAsyncActor(cache, 100)), name = getName)
     }
   }
 
@@ -179,7 +178,7 @@ trait AsyncSetup {
 
     override lazy val controller : ExampleAsyncController = new ExampleAsyncController() {
       override lazy val stockConnector : StockConnector = ???
-      override lazy val sessionHttpCache  = ???
+      override lazy val taskCache  = ???
       override def buildUniqueId() = testSessionId
       override def waitMode = true
       override def throttleLimit = 0
@@ -192,7 +191,7 @@ trait AsyncSetup {
 
     override lazy val controller : ExampleAsyncController = new ExampleAsyncController() {
       override lazy val stockConnector : StockConnector = ???
-      override lazy val sessionHttpCache  = ???
+      override lazy val taskCache  = ???
       override def buildUniqueId() = testSessionId
       override def waitMode = false
       override def throttleLimit = 0
@@ -210,7 +209,7 @@ trait AsyncSetup {
       override def buildUniqueId() = testSessionId
       override def waitMode = true
       override def getClientTimeout = 5000
-      override lazy val asyncActor: ActorRef = Akka.system.actorOf(Props(new AsyncMVCAsyncActor(sessionHttpCache, getClientTimeout)), name = getName)
+      override lazy val asyncActor: ActorRef = Akka.system.actorOf(Props(new AsyncMVCAsyncActor(cache, getClientTimeout)), name = getName)
     }
   }
 
@@ -223,7 +222,7 @@ trait AsyncSetup {
       override def buildUniqueId() = testSessionId
       override def waitMode = true
       override def getClientTimeout = 80000
-      override lazy val asyncActor: ActorRef = Akka.system.actorOf(Props(new AsyncMVCAsyncActor(sessionHttpCache, getClientTimeout)), name = getName)
+      override lazy val asyncActor: ActorRef = Akka.system.actorOf(Props(new AsyncMVCAsyncActor(cache, getClientTimeout)), name = getName)
     }
   }
 

--- a/test/uk/gov/hmrc/play/asyncmvc/example/controllers/AsyncMvcIntegration.scala
+++ b/test/uk/gov/hmrc/play/asyncmvc/example/controllers/AsyncMvcIntegration.scala
@@ -51,7 +51,7 @@ trait AsyncMvcIntegration extends AsyncMVC[Stock] {
 
   final val CLIENT_TIMEOUT=8000L
 
-  lazy val asyncActor: ActorRef = Akka.system.actorOf(Props(new AsyncMVCAsyncActor(sessionHttpCache, CLIENT_TIMEOUT)), actorName)
+  lazy val asyncActor: ActorRef = Akka.system.actorOf(Props(new AsyncMVCAsyncActor(taskCache, CLIENT_TIMEOUT)), actorName)
   override def         actorRef = asyncActor
   override def getClientTimeout = CLIENT_TIMEOUT
 


### PR DESCRIPTION
Supplying the taskId to the callback functions provides the user of the library to have control over the persistence mechanism and the ability to remove cached records once the task has completed processing. 

Other minor cleanup with renaming the cache object since play-async has no dependency on http-caching.  