### PR TITLE
NGC-2331 Upgrade to Scala 2.11.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,8 @@ name := "play-async"
 lazy val library = (project in file("."))
   .enablePlugins(SbtAutoBuildPlugin, SbtGitVersioning)
   .settings(
-    scalaVersion := "2.11.8",
-    crossScalaVersions := Seq("2.11.8"),
+    scalaVersion := "2.11.11",
+    crossScalaVersions := Seq("2.11.11"),
     libraryDependencies ++= AppDependencies(),
     resolvers := Seq(
       Resolver.bintrayRepo("hmrc", "releases"),


### PR DESCRIPTION
Most projects using this lib will be on 2.11.11 because <confluence>/display/PLATOPS/Bootstrap+libraries+migration+guide recommends upgrading to it.